### PR TITLE
[Feature] 선착순 이벤트 유저 등록 도메인 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    //redission
+    implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
+    implementation "org.redisson:redisson-spring-data-27:3.33.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/softeer/podoarrival/common/response/ErrorCode.java
+++ b/src/main/java/com/softeer/podoarrival/common/response/ErrorCode.java
@@ -23,11 +23,8 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_ERROR(false, HttpStatus.BAD_REQUEST.value(), "RefreshToken 정보를 찾을 수 없습니다."),
     USERNAME_EXISTS_ERROR(false, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다."),
 
-    //event_lots
-    PHONENUM_EXSIST_ERROR(false, HttpStatus.BAD_REQUEST.value(),"이미 존재하는 전화번호입니다."),
-    INVALID_SELECTION_ERROR(false, HttpStatus.BAD_REQUEST.value(), "선택지 형식이 잘못되었습니다."),
-    USER_NOT_EXIST_ERROR(false, HttpStatus.BAD_REQUEST.value(), "해당 사용자가 아직 이벤트에 응모하지 않았습니다."),
-    EXISTING_COMMENT_ERROR(false, HttpStatus.BAD_REQUEST.value(),"이미 기대평을 작성했습니다."),
+    //event_arrival
+    PHONENUM_EXSIST_ERROR(false, HttpStatus.BAD_REQUEST.value(),"이미 응모 전화번호입니다.")
     ;
 
 

--- a/src/main/java/com/softeer/podoarrival/config/FilterConfig.java
+++ b/src/main/java/com/softeer/podoarrival/config/FilterConfig.java
@@ -21,6 +21,7 @@ public class FilterConfig {
         FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(new JwtAuthenticationFilter(tokenProvider));
         registrationBean.addUrlPatterns("/test/auth"); // 필터를 적용할 URL 패턴
+        registrationBean.addUrlPatterns("/v1/arrival/*");
         registrationBean.setOrder(2); // 필터의 순서 (숫자가 낮을수록 먼저 실행됨)
         return registrationBean;
     }

--- a/src/main/java/com/softeer/podoarrival/config/RedissionConfig.java
+++ b/src/main/java/com/softeer/podoarrival/config/RedissionConfig.java
@@ -1,0 +1,19 @@
+package com.softeer.podoarrival.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class RedissionConfig {
+    @Bean
+    public RedissonClient redisson() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://127.0.0.1:6379");
+        return  Redisson.create(config);
+    }
+}

--- a/src/main/java/com/softeer/podoarrival/config/RedissionConfig.java
+++ b/src/main/java/com/softeer/podoarrival/config/RedissionConfig.java
@@ -3,17 +3,21 @@ package com.softeer.podoarrival.config;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 
 @Configuration
 public class RedissionConfig {
+    @Value("${secret.redis-url}")
+    private String redisUrl;
+
     @Bean
     public RedissonClient redisson() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://127.0.0.1:6379");
+                .setAddress(redisUrl);
         return  Redisson.create(config);
     }
 }

--- a/src/main/java/com/softeer/podoarrival/event/controller/ArrivalEventController.java
+++ b/src/main/java/com/softeer/podoarrival/event/controller/ArrivalEventController.java
@@ -1,0 +1,31 @@
+package com.softeer.podoarrival.event.controller;
+
+
+import com.softeer.podoarrival.common.response.CommonResponse;
+import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
+import com.softeer.podoarrival.event.service.ArrivalEventService;
+import com.softeer.podoarrival.security.Auth;
+import com.softeer.podoarrival.security.AuthInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/arrival")
+@Slf4j
+public class ArrivalEventController {
+
+    private final ArrivalEventService arrivalEventService;
+
+    @PostMapping("/application")
+    @Operation(summary = "선착순 응모용 Api")
+    public CommonResponse<ArrivalApplicationResponseDto> arrivalEventApplicaion(@Auth AuthInfo authInfo){
+        return new CommonResponse<>(arrivalEventService.application(authInfo));
+    }
+
+
+}

--- a/src/main/java/com/softeer/podoarrival/event/exception/ArrivalEventExceptionHandler.java
+++ b/src/main/java/com/softeer/podoarrival/event/exception/ArrivalEventExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.softeer.podoarrival.event.exception;
+
+
+import com.softeer.podoarrival.common.response.CommonResponse;
+import com.softeer.podoarrival.common.response.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ArrivalEventExceptionHandler {
+
+    @ExceptionHandler(ExistingUserException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public CommonResponse<?> existingUserException(ExistingUserException e, HttpServletRequest request) {
+        log.warn("ARRIVALAPPLICATION-001> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
+        return new CommonResponse<>(ErrorCode.PHONENUM_EXSIST_ERROR);
+    }
+
+}

--- a/src/main/java/com/softeer/podoarrival/event/exception/ExistingUserException.java
+++ b/src/main/java/com/softeer/podoarrival/event/exception/ExistingUserException.java
@@ -1,0 +1,9 @@
+package com.softeer.podoarrival.event.exception;
+
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ExistingUserException extends RuntimeException {
+    private String message;
+}

--- a/src/main/java/com/softeer/podoarrival/event/model/dto/ArrivalApplicationResponseDto.java
+++ b/src/main/java/com/softeer/podoarrival/event/model/dto/ArrivalApplicationResponseDto.java
@@ -1,0 +1,13 @@
+package com.softeer.podoarrival.event.model.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArrivalApplicationResponseDto {
+    private String response;
+}

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
@@ -20,9 +20,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class ArrivalEventService {
     private final RedissonClient redissonClient;
-    @Value("${secret.max-arrival-count}")
-    private int maxArrival;
-    private boolean maxarrived = false;
+    private final int maxArrival = 100;
     private final String finished = "finished";
 
     @Transactional

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
@@ -1,0 +1,54 @@
+package com.softeer.podoarrival.event.service;
+
+
+import com.softeer.podoarrival.common.response.CommonResponse;
+import com.softeer.podoarrival.event.exception.ExistingUserException;
+import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
+import com.softeer.podoarrival.security.AuthInfo;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.BatchResult;
+import org.redisson.api.RBatch;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ArrivalEventService {
+    private final RedissonClient redissonClient;
+    private final int maxArrival = 100;
+    private boolean maxarrived = false;
+    private final String finished = "finished";
+
+    @Transactional
+    public ArrivalApplicationResponseDto application(AuthInfo authInfo){
+        LocalDate now = LocalDate.now();
+        RBucket<String> check = redissonClient.getBucket(now.toString() + "check");
+
+        if(check.get() != null && check.get().equals(finished)){
+            return new ArrivalApplicationResponseDto("failed");
+        }
+
+        RBatch batch = redissonClient.createBatch();
+        batch.getSet(now.toString() + "arrivalset").addAsync(authInfo.getPhoneNum());
+        batch.getSet(now.toString() + "arrivalset").sizeAsync();
+        BatchResult<?> res = batch.execute();
+
+        //첫번째 응답인
+        if(!(boolean) res.getResponses().get(0)){
+            throw new ExistingUserException("이미 응모한 전화번호입니다.");
+        }
+
+        if((int) res.getResponses().get(1) <= maxArrival){
+            return new ArrivalApplicationResponseDto("success");
+        }else{
+            check.set(finished);
+            return new ArrivalApplicationResponseDto("failed");
+        }
+    }
+
+
+}

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
@@ -10,6 +10,7 @@ import org.redisson.api.BatchResult;
 import org.redisson.api.RBatch;
 import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +20,8 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class ArrivalEventService {
     private final RedissonClient redissonClient;
-    private final int maxArrival = 100;
+    @Value("${secret.max-arrival-count}")
+    private int maxArrival;
     private boolean maxarrived = false;
     private final String finished = "finished";
 
@@ -37,7 +39,7 @@ public class ArrivalEventService {
         batch.getSet(now.toString() + "arrivalset").sizeAsync();
         BatchResult<?> res = batch.execute();
 
-        //첫번째 응답인
+        //첫번째 응답
         if(!(boolean) res.getResponses().get(0)){
             throw new ExistingUserException("이미 응모한 전화번호입니다.");
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,3 @@ spring:
 secret:
     jwt: ${SECRET_JWT}
     redis-url: ${REDIS_URL}
-    max-arrival-count: ${MAX_COUNT}
-
-
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,8 @@ spring:
 
 secret:
     jwt: ${SECRET_JWT}
+    redis-url: ${REDIS_URL}
+    max-arrival-count: ${MAX_COUNT}
+
+
+

--- a/src/test/java/com/softeer/podoarrival/event/service/ArrivalEventServiceTest.java
+++ b/src/test/java/com/softeer/podoarrival/event/service/ArrivalEventServiceTest.java
@@ -1,0 +1,74 @@
+package com.softeer.podoarrival.event.service;
+
+import com.softeer.podoarrival.PodoArrivalApplication;
+import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
+import com.softeer.podoarrival.security.AuthInfo;
+import com.softeer.podoarrival.user.model.entity.Role;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@ContextConfiguration(classes = PodoArrivalApplication.class)
+class ArrivalEventServiceTest {
+
+    @Autowired
+    ArrivalEventService arrivalEventService;
+
+    @Autowired
+    RedissonClient redissonClient;
+
+    @AfterEach
+    void tearDown() {
+        redissonClient.getKeys().flushdb();
+        redissonClient.shutdown();
+    }
+
+    @Test
+    @DisplayName("선착순 api 정확도 테스트")
+    void applicationTest() throws InterruptedException {
+        //given
+        int threadCount = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        AtomicInteger count = new AtomicInteger();
+
+        //when
+        for (int i = 0; i < threadCount; i++) {
+            long userId = i;
+            executorService.submit(() -> {
+                try {
+                    ArrivalApplicationResponseDto res= arrivalEventService.application(
+                            new AuthInfo(
+                                    "teat" + userId,
+                                    "010-1234-5678-" + userId,
+                                    Role.ROLE_USER
+                            )
+                    );
+                    if(res.getResponse().equals("success")) count.getAndIncrement();
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        //then
+        redissonClient.getSet("arrivalset").clear();
+        assertEquals(100, count.get());
+    }
+}

--- a/src/test/java/com/softeer/podoarrival/event/service/ArrivalEventServiceTest.java
+++ b/src/test/java/com/softeer/podoarrival/event/service/ArrivalEventServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ContextConfiguration;
@@ -38,11 +39,14 @@ class ArrivalEventServiceTest {
         redissonClient.shutdown();
     }
 
+    @Value("${MAX_COUNT}")
+    private int MAX_COUNT;
+
     @Test
     @DisplayName("선착순 api 정확도 테스트")
     void applicationTest() throws InterruptedException {
         //given
-        int threadCount = 1000;
+        int threadCount = 100000;
         ExecutorService executorService = Executors.newFixedThreadPool(32);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         AtomicInteger count = new AtomicInteger();
@@ -69,6 +73,6 @@ class ArrivalEventServiceTest {
 
         //then
         redissonClient.getSet("arrivalset").clear();
-        assertEquals(100, count.get());
+        assertEquals(MAX_COUNT, count.get());
     }
 }


### PR DESCRIPTION
## 🎯 이슈 번호
#1 선착순 응모 인원수 제한 및 등록

## 💡 작업 내용

- [x] 정해진 인원수만큼 당첨자를 제한
- [x] 중복된 응모에 대한 거절 구현
## 💡 자세한 설명

redis set을 이용하여 set에 넣고 set의 element 갯수 확인을 pipelining하여 atomic하게 처리
이후 결과를 통해 set에 넣어졌는지로 중복 체크, element 갯수로 인원수 제한 체크

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
