### PR TITLE
[Feat] 이벤트 시간 체크 로직 추가

### DIFF
--- a/src/main/java/com/softeer/podoarrival/common/response/ErrorCode.java
+++ b/src/main/java/com/softeer/podoarrival/common/response/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
 
     //event_arrival
     PHONENUM_EXISTS_ERROR(false, HttpStatus.BAD_REQUEST.value(),"이미 응모한 전화번호입니다."),
-    QUIZ_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "오늘 날짜에 퀴즈가 없습니다.")
+    QUIZ_NOT_FOUND(false, HttpStatus.NOT_FOUND.value(), "오늘 날짜에 퀴즈가 없습니다."),
+    EVENT_CLOSED(false, HttpStatus.FORBIDDEN.value(), "이벤트 시간이 아닙니다.")
     ;
 
 

--- a/src/main/java/com/softeer/podoarrival/event/exception/ArrivalEventExceptionHandler.java
+++ b/src/main/java/com/softeer/podoarrival/event/exception/ArrivalEventExceptionHandler.java
@@ -34,4 +34,11 @@ public class ArrivalEventExceptionHandler {
         log.warn("ARRIVAL-003> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
         return new CommonResponse<>(ErrorCode.QUIZ_NOT_FOUND);
     }
+
+    @ExceptionHandler(EventClosedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CommonResponse<?> eventClosedException(EventClosedException e, HttpServletRequest request) {
+        log.warn("ARRIVAL-004> 요청 URI: " + request.getRequestURI() + ", 에러 메세지: " + e.getMessage());
+        return new CommonResponse<>(ErrorCode.EVENT_CLOSED);
+    }
 }

--- a/src/main/java/com/softeer/podoarrival/event/exception/EventClosedException.java
+++ b/src/main/java/com/softeer/podoarrival/event/exception/EventClosedException.java
@@ -1,0 +1,8 @@
+package com.softeer.podoarrival.event.exception;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class EventClosedException extends RuntimeException {
+	private String message;
+}

--- a/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
+++ b/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
@@ -48,6 +48,8 @@ public class ArrivalEventInformationScheduler {
 
         if(findEvent == null) {
             log.warn("오늘 날짜에 이벤트가 없습니다.");
+            ArrivalEventReleaseServiceRedisImpl.setMaxArrival(0);
+            ArrivalEventReleaseServiceJavaImpl.setMaxArrival(0);
             return;
         }
 

--- a/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
+++ b/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 /**
@@ -24,18 +25,19 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ArrivalEventMaxArrivalScheduler {
+public class ArrivalEventInformationScheduler {
 
     private final EventRepository eventRepository;
     private final EventTypeRepository eventTypeRepository;
     private final EventRewardRepository eventRewardRepository;
 
     /**
-     * 특정 시간에 Mysql에서 금일 진행될 선착순 이벤트의 당첨자 수를 읽어옴
+     * 특정 시간에 Mysql에서 금일 진행될 선착순 이벤트의 절보를 세팅함.
+     * 당첨자 수, 이벤트 시작 시간, 이벤트 요일 설정
      *
      */
     @Scheduled(cron = "0 25 03 * * *")
-    public void setEventArrivalCount() {
+    public void setArrivalEventInformation() {
         // 시작일자, 이벤트 종류만 고려하여 이벤트 추출
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
         LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
@@ -44,6 +46,11 @@ public class ArrivalEventMaxArrivalScheduler {
         EventType eventType = eventTypeRepository.findById(1L).orElseThrow(() -> new EventTypeNotExistsException("이벤트 타입이 존재하지 않습니다."));
         Event findEvent = eventRepository.findFirstByEventTypeAndStartAtBetween(eventType, startOfDay, endOfDay);
 
+        if(findEvent == null) {
+            log.warn("오늘 날짜에 이벤트가 없습니다.");
+            return;
+        }
+
         // 찾은 이벤트에 해당하는 reward개수 조회
         int rewardCount = 0;
         List<EventReward> eventRewards = eventRewardRepository.findAllByEvent(findEvent);
@@ -51,7 +58,25 @@ public class ArrivalEventMaxArrivalScheduler {
             rewardCount += eventReward.getNumWinners();
         }
 
+        // 찾은 이벤트에 해당하는 반복 시간 확인
+        LocalTime repeatTime = findEvent.getRepeatTime();
+
+        // 찾은 이벤트에 해당하는 반복 요일 확인 및 저장
+        String repeatDate = findEvent.getRepeatDay();
+        int today = startOfDay.getDayOfWeek().getValue();
+        if(repeatDate.length() >= 7 && repeatDate.charAt(today - 1) == '1') {
+            ArrivalEventReleaseServiceRedisImpl.setStartDate(true);
+            ArrivalEventReleaseServiceJavaImpl.setStartDate(true);
+        }else{
+            ArrivalEventReleaseServiceRedisImpl.setStartDate(false);
+            ArrivalEventReleaseServiceJavaImpl.setStartDate(false);
+        }
+
+        // service에 이벤트 내용 저장
         ArrivalEventReleaseServiceRedisImpl.setMaxArrival(rewardCount);
         ArrivalEventReleaseServiceJavaImpl.setMaxArrival(rewardCount);
+
+        ArrivalEventReleaseServiceRedisImpl.setStartTime(repeatTime);
+        ArrivalEventReleaseServiceJavaImpl.setStartTime(repeatTime);
     }
 }

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
@@ -86,4 +86,13 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
     public static int getMaxArrival() {
         return MAX_ARRIVAL;
     }
+
+
+    public static LocalTime getStartTime() {
+        return START_TIME;
+    }
+
+    public static boolean getStartDate() {
+        return START_DATE;
+    }
 }

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
@@ -1,5 +1,6 @@
 package com.softeer.podoarrival.event.service;
 
+import com.softeer.podoarrival.event.exception.EventClosedException;
 import com.softeer.podoarrival.event.exception.ExistingUserException;
 import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
 import com.softeer.podoarrival.event.model.entity.ArrivalUser;
@@ -41,6 +42,8 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
     @Override
     public CompletableFuture<ArrivalApplicationResponseDto> applyEvent(AuthInfo authInfo) {
         return CompletableFuture.supplyAsync(() -> {
+            if(!START_DATE) throw new EventClosedException("이벤트 요일이 아닙니다.");
+            if(LocalTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
 
             if(CHECK){
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), -1);

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,6 +27,8 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
 
     private static int MAX_ARRIVAL = 100; // default
     private boolean CHECK = false;
+    private static LocalTime START_TIME = LocalTime.of(0, 0);
+    private static boolean START_DATE = true;
 
     private static AtomicInteger count = new AtomicInteger(1);
     private static ConcurrentHashMap<String, Integer> hashMap = new ConcurrentHashMap<>();
@@ -70,6 +73,14 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
 
     public static void setMaxArrival(int val) {
         MAX_ARRIVAL = val;
+    }
+
+    public static void setStartTime(LocalTime val) {
+        START_TIME = val;
+    }
+
+    public static void setStartDate(Boolean val) {
+        START_DATE = val;
     }
 
     public static int getMaxArrival() {

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
@@ -61,9 +61,6 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
                 throw new ExistingUserException("이미 응모한 전화번호입니다.");
             }
 
-            // 로깅 추가
-            specialLogger.info("[응모] 유저 전화번호: {}", authInfo.getPhoneNum());
-
             int grade = (int) res.getResponses().get(1);
             // 선착순 순위에 들었다면
             if(grade <= MAX_ARRIVAL){

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
@@ -96,4 +96,12 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
     public static int getMaxArrival() {
         return MAX_ARRIVAL;
     }
+
+    public static LocalTime getStartTime() {
+        return START_TIME;
+    }
+
+    public static boolean getStartDate() {
+        return START_DATE;
+    }
 }

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
@@ -17,6 +17,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -32,6 +33,8 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
     private final String ARRIVAL_SET = "arrivalset";
     private boolean CHECK = false;
     private static int MAX_ARRIVAL = 100; // default
+    private static LocalTime START_TIME = LocalTime.of(0, 0);
+    private static boolean START_DATE = true;
 
     /**
      * 비동기로 Redis 호출하는 메서드
@@ -83,6 +86,14 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
 
     public static void setMaxArrival(int val) {
         MAX_ARRIVAL = val;
+    }
+
+    public static void setStartTime(LocalTime val) {
+        START_TIME = val;
+    }
+
+    public static void setStartDate(Boolean val) {
+        START_DATE = val;
     }
 
     public static int getMaxArrival() {

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
@@ -1,5 +1,6 @@
 package com.softeer.podoarrival.event.service;
 
+import com.softeer.podoarrival.event.exception.EventClosedException;
 import com.softeer.podoarrival.event.exception.ExistingUserException;
 import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
 import com.softeer.podoarrival.event.model.entity.ArrivalUser;
@@ -46,6 +47,9 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
     public CompletableFuture<ArrivalApplicationResponseDto> applyEvent(AuthInfo authInfo) {
         return CompletableFuture.supplyAsync(() -> {
             String redisKey = LocalDate.now() + ARRIVAL_SET;
+
+            if(!START_DATE) throw new EventClosedException("이벤트 요일이 아닙니다.");
+            if(LocalTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
 
             if(CHECK){
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), -1);

--- a/src/test/java/com/softeer/podoarrival/unit/base/ArrivalEventInformationBase.java
+++ b/src/test/java/com/softeer/podoarrival/unit/base/ArrivalEventInformationBase.java
@@ -5,7 +5,7 @@ import com.softeer.podoarrival.event.model.entity.EventReward;
 import com.softeer.podoarrival.event.repository.EventRepository;
 import com.softeer.podoarrival.event.repository.EventRewardRepository;
 import com.softeer.podoarrival.event.repository.EventTypeRepository;
-import com.softeer.podoarrival.event.scheduler.ArrivalEventMaxArrivalScheduler;
+import com.softeer.podoarrival.event.scheduler.ArrivalEventInformationScheduler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,10 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @ExtendWith(MockitoExtension.class)
-public class ArrivalEventMaxCountSchedulerBase {
+public class ArrivalEventInformationBase {
 
     @Mock
     protected EventRepository eventRepository;
@@ -28,7 +30,7 @@ public class ArrivalEventMaxCountSchedulerBase {
     protected EventTypeRepository eventTypeRepository;
 
     @InjectMocks
-    protected ArrivalEventMaxArrivalScheduler arrivalEventMaxArrivalScheduler;
+    protected ArrivalEventInformationScheduler arrivalEventInformationScheduler;
 
     protected Event eventSample;
     protected EventReward eventReward1;
@@ -42,6 +44,8 @@ public class ArrivalEventMaxCountSchedulerBase {
                 .description("The 2025 셀토스 출시 기념 선착순 이벤트")
                 .startAt(LocalDateTime.now())
                 .endAt(LocalDateTime.now().plusDays(5))
+                .repeatTime(LocalTime.of(15, 0))
+                .repeatDay("1111111")
                 .build();
 
         eventReward1 = EventReward.builder()

--- a/src/test/java/com/softeer/podoarrival/unit/event/ArrivalEventComplexServiceTest.java
+++ b/src/test/java/com/softeer/podoarrival/unit/event/ArrivalEventComplexServiceTest.java
@@ -28,10 +28,10 @@ public class ArrivalEventComplexServiceTest {
     private ArrivalEventService arrivalEventService;
 
     @Mock
-    private ArrivalEventReleaseServiceJavaImpl redisService;
+    private ArrivalEventReleaseServiceJavaImpl javaService;
 
     @Mock
-    private ArrivalEventReleaseServiceRedisImpl javaService;
+    private ArrivalEventReleaseServiceRedisImpl redisService;
 
     @Mock
     private RedissonClient redissonClient;

--- a/src/test/java/com/softeer/podoarrival/unit/scheduler/ArrivalEventInformationTest.java
+++ b/src/test/java/com/softeer/podoarrival/unit/scheduler/ArrivalEventInformationTest.java
@@ -1,26 +1,28 @@
 package com.softeer.podoarrival.unit.scheduler;
 
-import com.softeer.podoarrival.event.model.entity.Event;
 import com.softeer.podoarrival.event.model.entity.EventType;
 import com.softeer.podoarrival.event.service.ArrivalEventReleaseServiceJavaImpl;
 import com.softeer.podoarrival.event.service.ArrivalEventReleaseServiceRedisImpl;
-import com.softeer.podoarrival.unit.base.ArrivalEventMaxCountSchedulerBase;
+import com.softeer.podoarrival.unit.base.ArrivalEventInformationBase;
+import jakarta.transaction.Transactional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class ArrivalEventMaxCountSchedulerTest extends ArrivalEventMaxCountSchedulerBase {
+public class ArrivalEventInformationTest extends ArrivalEventInformationBase {
 
     @Test
-    @DisplayName("이벤트 최대인원 세팅 스케줄러 동작 테스트 (성공 - Mysql에 데이터가 존재하는 경우)")
+    @Transactional
+    @DisplayName("이벤트 정보 세팅 스케줄러 동작 테스트 (성공 - Mysql에 데이터가 존재하는 경우)")
     public void setArrivalEventCountSuccess_Data_Exists() {
         LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
         LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
@@ -39,17 +41,22 @@ public class ArrivalEventMaxCountSchedulerTest extends ArrivalEventMaxCountSched
 
 
         // when
-        arrivalEventMaxArrivalScheduler.setEventArrivalCount();
+        arrivalEventInformationScheduler.setArrivalEventInformation();
 
         // then
         Assertions.assertThat(ArrivalEventReleaseServiceRedisImpl.getMaxArrival())
                 .isEqualTo(60);
         Assertions.assertThat(ArrivalEventReleaseServiceJavaImpl.getMaxArrival())
                 .isEqualTo(60);
+        Assertions.assertThat(ArrivalEventReleaseServiceRedisImpl.getStartTime())
+                .isEqualTo(LocalTime.of(15, 0));
+        Assertions.assertThat(ArrivalEventReleaseServiceJavaImpl.getStartTime())
+                .isEqualTo(LocalTime.of(15, 0));
     }
 
     @Test
-    @DisplayName("이벤트 최대인원 세팅 스케줄러 동작 테스트 (성공 - Mysql에 데이터가 존재하지 않는 경우)")
+    @Transactional
+    @DisplayName("이벤트 정보 세팅 스케줄러 동작 테스트 (성공 - Mysql에 데이터가 존재하지 않는 경우)")
     public void setArrivalEventCountSuccess_Data_Not_Exists() {
         // given
         EventType arrivalType = EventType.builder()
@@ -63,7 +70,7 @@ public class ArrivalEventMaxCountSchedulerTest extends ArrivalEventMaxCountSched
                 .thenReturn(null);
 
         // when
-        arrivalEventMaxArrivalScheduler.setEventArrivalCount();
+        arrivalEventInformationScheduler.setArrivalEventInformation();
 
         // then
         Assertions.assertThat(ArrivalEventReleaseServiceRedisImpl.getMaxArrival())


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] 선착순 이벤트 응모 시간 체크 로직 추가

## 💡 자세한 설명
event 정보를 scheduler를 통해 새벽 시간대에 받아서 서버에 저장
이후 해당 정보를 가지고 이벤트 시간 및 요일 체크
## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
