### PR TITLE
[Feat] 선착순 응모가 완료되면 다음날 이벤트시간으로 카운트다운 되도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     //redission
     implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
     implementation "org.redisson:redisson-spring-data-27:3.33.0"
+    //webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/softeer/podoarrival/event/controller/ArrivalEventController.java
+++ b/src/main/java/com/softeer/podoarrival/event/controller/ArrivalEventController.java
@@ -3,6 +3,7 @@ package com.softeer.podoarrival.event.controller;
 
 import com.softeer.podoarrival.common.response.CommonResponse;
 import com.softeer.podoarrival.event.exception.AsyncRequestExecuteException;
+import com.softeer.podoarrival.event.exception.EventClosedException;
 import com.softeer.podoarrival.event.exception.ExistingUserException;
 import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
 import com.softeer.podoarrival.event.service.ArrivalEventService;
@@ -35,6 +36,8 @@ public class ArrivalEventController {
                     // 내부 예외 처리
                     if(ex.getCause() instanceof ExistingUserException) {
                         throw new ExistingUserException("[비동기 에러] 유저가 이미 존재합니다.");
+                    } else if(ex.getCause() instanceof EventClosedException){
+                        throw new EventClosedException(ex.getMessage());
                     } else {
                         log.error("Exception occurred while arrival application", ex);
                         throw new AsyncRequestExecuteException("[비동기 에러] 선착순 요청 중 서버 오류 발생");

--- a/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
+++ b/src/main/java/com/softeer/podoarrival/event/scheduler/ArrivalEventInformationScheduler.java
@@ -78,7 +78,7 @@ public class ArrivalEventInformationScheduler {
         ArrivalEventReleaseServiceRedisImpl.setMaxArrival(rewardCount);
         ArrivalEventReleaseServiceJavaImpl.setMaxArrival(rewardCount);
 
-        ArrivalEventReleaseServiceRedisImpl.setStartTime(repeatTime);
-        ArrivalEventReleaseServiceJavaImpl.setStartTime(repeatTime);
+        ArrivalEventReleaseServiceRedisImpl.setStartTime(LocalDateTime.of(LocalDate.now(), repeatTime));
+        ArrivalEventReleaseServiceJavaImpl.setStartTime(LocalDateTime.of(LocalDate.now(), repeatTime));
     }
 }

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseService.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseService.java
@@ -3,9 +3,12 @@ package com.softeer.podoarrival.event.service;
 import com.softeer.podoarrival.event.model.dto.ArrivalApplicationResponseDto;
 import com.softeer.podoarrival.security.AuthInfo;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
 
 public interface ArrivalEventReleaseService {
 
     CompletableFuture<ArrivalApplicationResponseDto> applyEvent(AuthInfo authInfo);
+
+    public LocalDateTime getStartTime();
 }

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceJavaImpl.java
@@ -14,6 +14,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,7 +30,7 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
 
     private static int MAX_ARRIVAL = 100; // default
     private boolean CHECK = false;
-    private static LocalTime START_TIME = LocalTime.of(0, 0);
+    private static LocalDateTime START_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0));
     private static boolean START_DATE = true;
 
     private static AtomicInteger count = new AtomicInteger(1);
@@ -43,7 +45,7 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
     public CompletableFuture<ArrivalApplicationResponseDto> applyEvent(AuthInfo authInfo) {
         return CompletableFuture.supplyAsync(() -> {
             if(!START_DATE) throw new EventClosedException("이벤트 요일이 아닙니다.");
-            if(LocalTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
+            if(LocalDateTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
 
             if(CHECK){
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), -1);
@@ -69,6 +71,7 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
                 return new ArrivalApplicationResponseDto(true, authInfo.getName(), authInfo.getPhoneNum(), grade);
             } else {
                 CHECK = true;
+                START_TIME = LocalDateTime.of(LocalDate.now().plusDays(1), START_TIME.toLocalTime());
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), grade);
             }
         });
@@ -78,7 +81,7 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
         MAX_ARRIVAL = val;
     }
 
-    public static void setStartTime(LocalTime val) {
+    public static void setStartTime(LocalDateTime val) {
         START_TIME = val;
     }
 
@@ -91,7 +94,11 @@ public class ArrivalEventReleaseServiceJavaImpl implements ArrivalEventReleaseSe
     }
 
 
-    public static LocalTime getStartTime() {
+    public LocalDateTime getStartTime() {
+        return START_TIME;
+    }
+
+    public static LocalDateTime getStartTimeStatic(){
         return START_TIME;
     }
 

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventReleaseServiceRedisImpl.java
@@ -18,6 +18,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,7 +35,7 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
     private final String ARRIVAL_SET = "arrivalset";
     private boolean CHECK = false;
     private static int MAX_ARRIVAL = 100; // default
-    private static LocalTime START_TIME = LocalTime.of(0, 0);
+    private static LocalDateTime START_TIME = LocalDateTime.of(LocalDate.now(), LocalTime.of(0, 0));
     private static boolean START_DATE = true;
 
     /**
@@ -49,7 +50,7 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
             String redisKey = LocalDate.now() + ARRIVAL_SET;
 
             if(!START_DATE) throw new EventClosedException("이벤트 요일이 아닙니다.");
-            if(LocalTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
+            if(LocalDateTime.now().isBefore(START_TIME)) throw new EventClosedException("이벤트 시간이 아닙니다.");
 
             if(CHECK){
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), -1);
@@ -80,6 +81,7 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
                 return new ArrivalApplicationResponseDto(true, authInfo.getName(), authInfo.getPhoneNum(), grade);
             } else {
                 CHECK = true;
+                START_TIME = LocalDateTime.of(LocalDate.now().plusDays(1), START_TIME.toLocalTime());
                 return new ArrivalApplicationResponseDto(false, authInfo.getName(), authInfo.getPhoneNum(), grade);
             }
         });
@@ -89,7 +91,7 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
         MAX_ARRIVAL = val;
     }
 
-    public static void setStartTime(LocalTime val) {
+    public static void setStartTime(LocalDateTime val) {
         START_TIME = val;
     }
 
@@ -101,7 +103,11 @@ public class ArrivalEventReleaseServiceRedisImpl implements ArrivalEventReleaseS
         return MAX_ARRIVAL;
     }
 
-    public static LocalTime getStartTime() {
+    public LocalDateTime getStartTime() {
+        return START_TIME;
+    }
+
+    public static LocalDateTime getStartTimeStatic(){
         return START_TIME;
     }
 

--- a/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
+++ b/src/main/java/com/softeer/podoarrival/event/service/ArrivalEventService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -37,8 +37,8 @@ public class ArrivalEventService {
                 Flux.just(0L), // Emit initial value immediately
                 Flux.interval(Duration.ofSeconds(20)))
                 .map(sequence -> {
-                    LocalTime startTime = ArrivalEventReleaseServiceJavaImpl.getStartTime();
-                    long seconds = Duration.between(LocalTime.now(), startTime).getSeconds();
+                    LocalDateTime startTime = arrivalEventReleaseServiceRedisImpl.getStartTime();
+                    long seconds = Duration.between(LocalDateTime.now(), startTime).getSeconds();
                     return Math.max(seconds, 0);
                 });
     }

--- a/src/test/java/com/softeer/podoarrival/unit/scheduler/ArrivalEventInformationTest.java
+++ b/src/test/java/com/softeer/podoarrival/unit/scheduler/ArrivalEventInformationTest.java
@@ -48,9 +48,9 @@ public class ArrivalEventInformationTest extends ArrivalEventInformationBase {
                 .isEqualTo(60);
         Assertions.assertThat(ArrivalEventReleaseServiceJavaImpl.getMaxArrival())
                 .isEqualTo(60);
-        Assertions.assertThat(ArrivalEventReleaseServiceRedisImpl.getStartTime())
+        Assertions.assertThat(ArrivalEventReleaseServiceRedisImpl.getStartTimeStatic())
                 .isEqualTo(LocalTime.of(15, 0));
-        Assertions.assertThat(ArrivalEventReleaseServiceJavaImpl.getStartTime())
+        Assertions.assertThat(ArrivalEventReleaseServiceJavaImpl.getStartTimeStatic())
                 .isEqualTo(LocalTime.of(15, 0));
     }
 


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] ArrivalEventReleaseService interface에 getStartTime method 추가
- [x] 기존에 있던 static method도 이름을 변경하여 유지
- [x] start time을 local date가 아닌 localDatetimed으로 저장하게끔 수정

## 💡 자세한 설명

(가능한 한 자세히 작성해 주시면 도움이 됩니다.)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
